### PR TITLE
Add SHA256 News React site

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# fantastic-memory
+# SHA256 News
+
+A single-page React site styled with Tailwind CSS that highlights the latest Bitcoin mining headlines. Built with Vite so it can be deployed easily to GitHub Pages.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The site will be available at [http://localhost:5173](http://localhost:5173).
+
+## Build for production
+
+```bash
+npm run build
+```
+
+The static assets will be generated in the `dist/` folder and can be published to GitHub Pages. The app fetches headline data from `public/api/sha256news-tweets.json`, so make sure that file is deployed with the build output.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>SHA256 News</title>
+  </head>
+  <body class="bg-zinc-950">
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "fantastic-memory",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.2.1",
+    "autoprefixer": "^10.4.19",
+    "postcss": "^8.4.38",
+    "tailwindcss": "^3.4.4",
+    "vite": "^5.2.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/api/sha256news-tweets.json
+++ b/public/api/sha256news-tweets.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "text": "Riot Platforms just energized 40 MW of new immersion-cooled capacity in Corsicana, pushing network hashrate to new highs.",
+    "url": "https://x.com/SHA256News/status/1",
+    "media": [
+      "https://images.unsplash.com/photo-1614064641938-3bbee52959f3?auto=format&fit=crop&w=400&q=80"
+    ]
+  },
+  {
+    "id": "2",
+    "text": "Luxor reports hashprice slipped 1.2% on the day despite bitcoin holding $63.8k as difficulty readjusts upward.",
+    "url": "https://x.com/SHA256News/status/2"
+  },
+  {
+    "id": "3",
+    "text": "DOE energy index ticked down as Texas wind output surged overnight, easing pressure on miners ahead of the summer heat.",
+    "url": "https://x.com/SHA256News/status/3"
+  }
+]

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <rect width="64" height="64" rx="12" fill="#27272A" />
+  <path d="M18 44L32 20L46 44" stroke="#22C55E" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+  <circle cx="32" cy="32" r="6" fill="#22C55E" />
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,221 @@
+import React, { useEffect, useState } from 'react';
+
+const lead = {
+  title: 'Hashrate hits record as new rigs come online',
+  deck: 'Bitcoin mining difficulty surges after a wave of next-gen ASICs are deployed in North America.',
+  byline: 'By SHA256 News Desk',
+  time: 'Updated 1 hour ago',
+};
+
+const markets = [
+  { s: 'Hashprice', p: '$72.10/PH/s/day', c: '−1.2%' },
+  { s: 'BTC', p: '$63,842', c: '+0.4%' },
+  { s: 'Mining Difficulty', p: '82.1 T', c: '+0.9%' },
+  { s: 'Energy Index', p: '$54.20/MWh', c: '−0.5%' },
+];
+
+export default function App() {
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 flex flex-col">
+      <Masthead />
+      <MarketsStrip />
+      <main className="flex-1 mx-auto w-full max-w-3xl px-4 sm:px-6 lg:px-8 py-12 space-y-16">
+        <article>
+          <h1 className="font-serif text-3xl sm:text-4xl leading-tight tracking-tight">{lead.title}</h1>
+          <p className="mt-3 text-lg leading-relaxed text-zinc-300">{lead.deck}</p>
+          <div className="mt-3 text-xs uppercase tracking-widest text-zinc-400">
+            <span className="font-semibold">{lead.byline}</span>
+            <span className="mx-2">•</span>
+            <time>{lead.time}</time>
+          </div>
+        </article>
+        <LatestHeadlinesWidget />
+        <Newsletter />
+      </main>
+      <Footer />
+    </div>
+  );
+}
+
+function Masthead() {
+  return (
+    <header className="border-b border-zinc-800">
+      <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+        <div className="py-6 text-center">
+          <h1 className="font-serif text-4xl sm:text-5xl">SHA256 News</h1>
+          <div className="mt-2 text-[11px] tracking-widest uppercase text-zinc-400">
+            Bitcoin Mining •{' '}
+            {new Date().toLocaleDateString(undefined, {
+              year: 'numeric',
+              month: 'long',
+              day: 'numeric',
+            })}
+          </div>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+function MarketsStrip() {
+  return (
+    <div className="border-b border-zinc-800 bg-zinc-950">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-wrap justify-center gap-x-6 gap-y-2 py-3 text-sm">
+          {markets.map((m, i) => (
+            <div key={i} className="flex items-baseline gap-2">
+              <span className="font-semibold">{m.s}</span>
+              <span className="tabular-nums">{m.p}</span>
+              <span
+                className={`tabular-nums ${m.c.startsWith('+') ? 'text-emerald-400' : 'text-red-400'}`}
+              >
+                {m.c}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function LatestHeadlinesWidget() {
+  const [tweets, setTweets] = useState([]);
+  const [error, setError] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [useEmbed, setUseEmbed] = useState(false);
+
+  useEffect(() => {
+    if (useEmbed) {
+      const existing = document.getElementById('x-wjs');
+      if (!existing) {
+        const s = document.createElement('script');
+        s.id = 'x-wjs';
+        s.async = true;
+        s.src = 'https://platform.twitter.com/widgets.js';
+        document.body.appendChild(s);
+      } else if (window.twttr && window.twttr.widgets) {
+        window.twttr.widgets.load();
+      }
+      return undefined;
+    }
+
+    let ignore = false;
+
+    async function fetchTweets() {
+      try {
+        const res = await fetch(`${import.meta.env.BASE_URL}api/sha256news-tweets.json`);
+        if (!res.ok) {
+          throw new Error('Network response was not ok');
+        }
+        const data = await res.json();
+        if (!ignore) {
+          setTweets(Array.isArray(data) ? data : []);
+        }
+      } catch (e) {
+        if (!ignore) {
+          setError(true);
+        }
+      } finally {
+        if (!ignore) {
+          setLoading(false);
+        }
+      }
+    }
+
+    fetchTweets();
+
+    return () => {
+      ignore = true;
+    };
+  }, [useEmbed]);
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between border-b border-zinc-800 pb-2">
+        <h2 className="text-xl font-serif">Latest Headlines</h2>
+        <button
+          onClick={() => setUseEmbed((v) => !v)}
+          className="text-xs border border-zinc-600 px-2 py-1 rounded hover:bg-zinc-800"
+        >
+          {useEmbed ? 'Use Server Feed' : 'Load X Embed'}
+        </button>
+      </div>
+      {useEmbed ? (
+        <div className="border border-zinc-800 bg-zinc-900 p-3 rounded-md">
+          <a
+            className="twitter-timeline"
+            data-theme="dark"
+            data-chrome="transparent noheader nofooter"
+            data-tweet-limit="5"
+            href="https://x.com/SHA256News"
+          >
+            Tweets by @SHA256News
+          </a>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {error ? (
+            <div className="text-sm text-zinc-300">
+              Could not load feed.{' '}
+              <a className="underline" href="https://x.com/SHA256News" target="_blank" rel="noreferrer">
+                Open @SHA256News on X
+              </a>
+              .
+            </div>
+          ) : loading ? (
+            <div className="text-xs text-zinc-500">Loading feed…</div>
+          ) : (
+            <ul className="space-y-3">
+              {tweets.map((t) => (
+                <li key={t.id} className="border border-zinc-800 bg-zinc-900 p-3 rounded-md">
+                  <p className="text-sm text-zinc-200">{t.text}</p>
+                  {Array.isArray(t.media) && t.media.length > 0 && (
+                    <div className="mt-2 flex gap-2 overflow-x-auto">
+                      {t.media.map((m, i) => (
+                        <img key={i} src={m} alt="media" className="h-20 w-20 object-cover rounded" />
+                      ))}
+                    </div>
+                  )}
+                  <a
+                    href={t.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="mt-2 block text-xs text-emerald-400 underline"
+                  >
+                    View on X
+                  </a>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function Newsletter() {
+  return (
+    <section className="border border-zinc-800 bg-zinc-900 p-6 text-center">
+      <h3 className="font-serif text-xl">Stay Updated</h3>
+      <p className="mt-1 text-sm text-zinc-400">Get early Bitcoin mining news in your inbox.</p>
+      <form className="mt-3 flex flex-col sm:flex-row gap-2 justify-center" onSubmit={(e) => e.preventDefault()}>
+        <input
+          type="email"
+          placeholder="you@company.com"
+          className="w-full sm:w-64 border border-zinc-700 bg-zinc-950 px-3 py-2 text-sm placeholder:text-zinc-500 focus:outline-none focus:ring-0"
+        />
+        <button className="border border-zinc-100 px-4 py-2 text-sm font-semibold">Subscribe</button>
+      </form>
+    </section>
+  );
+}
+
+function Footer() {
+  return (
+    <footer className="mt-16 border-t border-zinc-800 py-6 text-sm text-zinc-400 text-center">
+      <div>© {new Date().getFullYear()} SHA256 Media — Bitcoin Mining Only</div>
+    </footer>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: ['./index.html', './src/**/*.{js,jsx}'],
+  theme: {
+    extend: {
+      fontFamily: {
+        serif: ['"Playfair Display"', 'ui-serif', 'Georgia', 'serif'],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const repoBase = '/fantastic-memory/';
+
+export default defineConfig(({ mode }) => ({
+  base: mode === 'production' ? repoBase : '/',
+  plugins: [react()],
+}));


### PR DESCRIPTION
## Summary
- scaffold a Vite + React project configured for deployment to GitHub Pages
- implement the SHA256 News landing page with market strip, latest headlines widget, and newsletter form
- add Tailwind CSS styling plus mock tweet data and favicon assets

## Testing
- npm install *(fails: registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e550bce10c83298bb855acd1a521f2